### PR TITLE
Add trackStatus argument for deploy_android

### DIFF
--- a/lib/src/deploy_android.dart
+++ b/lib/src/deploy_android.dart
@@ -27,6 +27,7 @@ Future<void> deploy({String? flavor}) async {
   final trackNameRaw = config?['trackName'] ?? 'internal';
   final trackName = trackNameRaw.toString();
   final generatedFileName = config?['generatedFileName']?? 'app-release.aab';
+  final trackStatus = config?['trackStatus']?? 'completed';
 
   DateTime startTime = DateTime.now();
 
@@ -80,7 +81,7 @@ Future<void> deploy({String? flavor}) async {
       releases: [
         TrackRelease(
           name: '${trackName.capitalize()} Release',
-          status: 'completed',
+          status: trackStatus,
           versionCodes: [uploadResponse.versionCode!.toString()],
           releaseNotes: [
             LocalizedText(


### PR DESCRIPTION
When running "dart run simple_deploy android"  to push an appbundle to an internal track that has the draft status, the command fails with the following exception:

```
Upload app bundle /Failed to upload to Play Console: DetailedApiRequestError(status: 400, message: Only releases with status draft may be created on draft app.)
```

setting the "status" arg of the TrackRelease builder to 'draft' solves it

cf https://pub.dev/documentation/googleapis/latest/androidpublisher_v3/TrackRelease/status.html